### PR TITLE
Fix License in setup.py; bundle in sdist and wheel

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,3 @@
 include package.json
+include LICENSE
+include LICENSE.dexie

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,4 @@
+[metadata]
+license_files =
+    LICENSE
+    LICENSE.dexie

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
         'jupyter_offlinenotebook',
     ],
     url='https://github.com/manics/jupyter-offlinenotebook',
-    license='MIT',
+    license='BSD-3-Clause',
     description='Save and load notebooks to local-storage',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
The shipped license is BSD-3-clause, not MIT.