### PR TITLE
Fix repo2docker/mybinder builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - "3.6"
 
 install:
-  - pip install flake8 jupyterlab
+  - pip install flake8 jupyterlab~=1.2
 
 script:
   - flake8 .

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-
+dist: bionic
 python:
   - "3.6"
 
@@ -7,11 +7,12 @@ install:
   - pip install flake8 jupyterlab~=1.2
 
 script:
+  - pwd
   - flake8 .
   - python setup.py sdist
   - python -mpip install dist/*.tar.gz
   - jlpm
-  - jupyter labextension install
+  - jupyter labextension install --debug
 
 deploy:
   - provider: pypi

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,5 +1,0 @@
-name: jupyter-offlinenotebook
-channels:
-  - conda-forge
-dependencies:
-  - jupyterlab=1.2

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,8 +1,15 @@
 #!/bin/bash
 set -eux
 
-env
+env | sort
 pwd
-pip install .
-jlpm
-jupyter labextension install
+
+# repo2docker copies this repo into $HOME which means jupyter labextension
+# picks up hidden dot files and runs into problems so install from a
+# different directory
+SRCDIR=/srv/conda/src/jupyter-offlinenotebook
+mkdir -p "$SRCDIR"
+cp -a * "$SRCDIR"
+cd "$SRCDIR"
+python -m pip install .
+jupyter labextension link --debug


### PR DESCRIPTION
Builds were failing due to the source repo being cloned into `$HOME`. `jupyter labextension` then picked up some unrelated files such as `~/.cache` and ended up creating a circular symlink:
```
Yarn configuration loaded.
Node v10.19.0

> /usr/bin/npm pack /home/user

> jupyter-offlinenotebook@0.0.11 prepare /home/user
> jlpm run clean && jlpm run build

yarn run v1.15.2
$ rimraf lib tsconfig.tsbuildinfo
Done in 0.12s.
yarn run v1.15.2
$ tsc
Done in 3.38s.
npm notice 
npm notice 📦  jupyter-offlinenotebook@0.0.11
npm notice === Tarball Contents === 
npm notice 1.5kB   LICENSE                                       
npm notice 0       jupyter_offlinenotebook/static/style/index.css
npm notice 11.3kB  LICENSE.dexie                                 
npm notice 225.8kB lib/dexie.js                                  
npm notice 75.9kB  lib/dexie.min.js                              
npm notice 8.3kB   lib/index.js                                  
npm notice 3.4kB   lib/offlinenotebook.js                        
npm notice 1.5kB   package.json                                  
npm notice 154.0kB lib/dexie.js.map                              
npm notice 133.1kB lib/dexie.min.js.map                          
npm notice 6.5kB   lib/index.js.map                              
npm notice 3.2kB   lib/offlinenotebook.js.map                    
npm notice 4.1kB   README.md                                     
npm notice === Tarball Details === 
npm notice name:          jupyter-offlinenotebook                 
npm notice version:       0.0.11                                  
npm notice filename:      jupyter-offlinenotebook-0.0.11.tgz      
npm notice package size:  126.3 kB                                
npm notice unpacked size: 628.7 kB                                
npm notice shasum:        b43150c95d6f9fad41048cc2fffee1083cd23a27
npm notice integrity:     sha512-e5rt5NbasWzlN[...]o/D6p5SSe1xXA==
npm notice total files:   13                                      
npm notice 
jupyter-offlinenotebook-0.0.11.tgz

Yarn configuration loaded.
Node v10.19.0

Building jupyterlab assets (build:dev:minimize)
> /usr/bin/npm pack /home/user

> jupyter-offlinenotebook@0.0.11 prepare /home/user
> jlpm run clean && jlpm run build

yarn run v1.15.2
$ rimraf lib tsconfig.tsbuildinfo
Done in 0.12s.
yarn run v1.15.2
$ tsc
Done in 3.46s.
npm notice 
npm notice 📦  jupyter-offlinenotebook@0.0.11
npm notice === Tarball Contents === 
npm notice 1.5kB   LICENSE                                       
npm notice 0       jupyter_offlinenotebook/static/style/index.css
npm notice 11.3kB  LICENSE.dexie                                 
npm notice 225.8kB lib/dexie.js                                  
npm notice 75.9kB  lib/dexie.min.js                              
npm notice 8.3kB   lib/index.js                                  
npm notice 3.4kB   lib/offlinenotebook.js                        
npm notice 1.5kB   package.json                                  
npm notice 154.0kB lib/dexie.js.map                              
npm notice 133.1kB lib/dexie.min.js.map                          
npm notice 6.5kB   lib/index.js.map                              
npm notice 3.2kB   lib/offlinenotebook.js.map                    
npm notice 4.1kB   README.md                                     
npm notice === Tarball Details === 
npm notice name:          jupyter-offlinenotebook                 
npm notice version:       0.0.11                                  
npm notice filename:      jupyter-offlinenotebook-0.0.11.tgz      
npm notice package size:  126.3 kB                                
npm notice unpacked size: 628.7 kB                                
npm notice shasum:        b43150c95d6f9fad41048cc2fffee1083cd23a27
npm notice integrity:     sha512-e5rt5NbasWzlN[...]o/D6p5SSe1xXA==
npm notice total files:   13                                      
npm notice 
jupyter-offlinenotebook-0.0.11.tgz

> node /srv/conda/envs/notebook/lib/python3.7/site-packages/jupyterlab/staging/yarn.js install --non-interactive
yarn install v1.15.2
[1/5] Validating package.json...
[2/5] Resolving packages...
[3/5] Fetching packages...
error An unexpected error occurred: "ENAMETOOLONG: name too long, lstat '/home/user/.cache/yarn/v4/npm-jupyter-offlinenotebook-0.0.11-6a77ae11-c87d-42b2-b674-4c30467fdb0e-1583676683108/node_modules/jupyter-offlinenotebook/.cache/yarn/v4/npm-jupyter-offlinenotebook-0.0.11-6a77ae11-c87d-42b2-b674-4c30467fdb0e-1583676683108/node_modules/jupyter-offlinenotebook/.cache/yarn/v4/npm-jupyter-offlinenotebook-0.0.11-6a77ae11-c87d-42b2-b674-4c30467fdb0e-1583676683108/node_modules/jupyter-offlinenotebook/.cache/yarn/v4/npm-jupyter-offlinenotebook-0.0.11-6a77ae11-c87d-42b2-b674-4c30467fdb0e-1583676683108/node_modules/jupyter-offlinenotebook/.cache/yarn/v4/npm-jupyter-offlinenotebook-0.0.11-6a77ae11-c87d-42b2-b674-4c30467fdb0e-1583676683108/node_modules/jupyter-offlinenotebook/.cache/yarn/v4/npm-jupyter-offlinenotebook-0.0.11-6a77ae11-c87d-42b2-b674-4c30467fdb0e-1583676683108/node_modules/jupyter-offlinenotebook/.cache/yarn/v4/npm-jupyter-offlinenotebook-0.0.11-6a77ae11-c87d-42b2-b674-4c30467fdb0e-1583676683108/node_modules/jupyter-offlinenotebook/.cache/yarn/v4/npm-jupyter-offlinenotebook-0.0.11-6a77ae11-c87d-42b2-b674-4c30467fdb0e-1583676683108/node_modules/jupyter-offlinenotebook/.cache/yarn/v4/npm-jupyter-offlinenotebook-0.0.11-6a77ae11-c87d-42b2-b674-4c30467fdb0e-1583676683108/node_modules/jupyter-offlinenotebook/.cache/yarn/v4/npm-jupyter-offlinenotebook-0.0.11-6a77ae11-c87d-42b2-b674-4c30467fdb0e-1583676683108/node_modules/jupyter-offlinenotebook/.cache/yarn/v4/npm-jupyter-offlinenotebook-0.0.11-6a77ae11-c87d-42b2-b674-4c30467fdb0e-1583676683108/node_modules/jupyter-offlinenotebook/.cache/yarn/v4/npm-jupyter-offlinenotebook-0.0.11-6a77ae11-c87d-42b2-b674-4c30467fdb0e-1583676683108/node_modules/jupyter-offlinenotebook/.cache/yarn/v4/npm-jupyter-offlinenotebook-0.0.11-6a77ae11-c87d-42b2-b674-4c30467fdb0e-1583676683108/node_modules/jupyter-offlinenotebook/.cache/yarn/v4/npm-jupyter-offlinenotebook-0.0.11-6a77ae11-c87d-42b2-b674-4c30467fdb0e-1583676683108/node_modules/jupyter-offlinenotebook/.cache/yarn/v4/npm-jupyter-offlinenotebook-0.0.11-6a77ae11-c87d-42b2-b674-4c30467fdb0e-1583676683108/node_modules/jupyter-offlinenotebook/.cache/yarn/v4/npm-jupyter-offlinenotebook-0.0.11-6a77ae11-c87d-42b2-b674-4c30467fdb0e-1583676683108/node_modules/jupyter-offlinenotebook/.cache/yarn/v4/npm-jupyter-offlinenotebook-0.0.11-6a77ae11-c87d-42b2-b674-4c30467fdb0e-1583676683108/node_modules/jupyter-offlinenotebook/.cache/yarn/v4/npm-jupyter-offlinenotebook-0.0.11-6a77ae11-c87d-42b2-b674-4c30467fdb0e-1583676683108/node_modules/jupyter-offlinenotebook/.cache/yarn/v4/npm-jupyter-offlinenotebook-0.0.11-6a77ae11-c87d-42b2-b674-4c30467fdb0e-1583676683108/node_modules/jupyter-offlinenotebook/.cache/yarn/v4/npm-jupyter-offlinenotebook-0.0.11-6a77ae11-c87d-42b2-b674-4c30467fdb0e-1583676683108/node_modules/jupyter-offlinenotebook/.cache/yarn/v4/npm-jupyter-offlinenotebook-0.0.11-6a77ae11-c87d-42b2-b674-4c30467fdb0e-1583676683108/node_modules/jupyter-offlinenotebook/.cache/yarn/v4/npm-jupyter-offlinenotebook-0.0.11-6a77ae11-c87d-42b2-b674-4c30467fdb0e-1583676683108/node_modules/jupyter-offlinenotebook/.cache/yarn/v4/npm-jupyter-offlinenotebook-0.0.11-6a77ae11-c87d-42b2-b674-4c30467fdb0e-1583676683108/node_modules/jupyter-offlinenotebook/.cache/yarn/v4/npm-jupyter-offlinenotebook-0.0.11-6a77ae11-c87d-42b2-b674-4c30467fdb0e-1583676683108/node_modules/jupyter-offlinenotebook/.cache/yarn/v4/npm-jupyter-offlinenotebook-0.0.11-6a77ae11-c87d-42b2-b674-4c30467fdb0e-1583676683108/node_modules/jupyter-offlinenotebook/.cache/yarn/v4/npm-jupyter-offlinenotebook-0.0.11-6a77ae11-c87d-42b2-b674-4c30467fdb0e-1583676683108/node_modules/jupyter-offlinenotebook/.cache/yarn/v4/npm-jupyter-offlinenotebook-0.0.11-6a77ae11-c87d-42b2-b674-4c30467fdb0e-1583676683108/node_modules/jupyter-offlinenotebook/.cache/yarn/v4/npm-jupyter-offlinenotebook-0.0.11-6a77ae11-c87d-42b2-b674-4c30467fdb0e-1583676683108/node_modules/jupyter-offlinenotebook/.cache/yarn/v4/npm-jupyter-offlinenotebook-0.0.11-6a77ae11-c87d-42b2-b674-4c30467fdb0e-1583676683108/node_modules/jupyter-offlinenotebook/.cache/yarn/v4/npm-@blueprintjs-core-3.23.1-346bd5430494cc2965fa9cac7366dc94c9dcf918'".
info If you think this is a bug, please open a bug report with the information provided in "/srv/conda/envs/notebook/share/jupyter/lab/staging/yarn-error.log".
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.

npm dependencies failed to install
Traceback (most recent call last):

  File "/srv/conda/envs/notebook/lib/python3.7/site-packages/jupyterlab/debuglog.py", line 47, in debug_logging
    yield

  File "/srv/conda/envs/notebook/lib/python3.7/site-packages/jupyterlab/labextensions.py", line 105, in start
    command=command, app_options=app_options)

  File "/srv/conda/envs/notebook/lib/python3.7/site-packages/jupyterlab/commands.py", line 459, in build
    command=command, clean_staging=clean_staging)

  File "/srv/conda/envs/notebook/lib/python3.7/site-packages/jupyterlab/commands.py", line 660, in build
    raise RuntimeError(msg)

RuntimeError: npm dependencies failed to install

Exiting application: jupyter
```
This switches to copying and installing the source from a different directory.

Closes #28