### PR TITLE
Include notebook in dev-requirements.txt

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,5 @@
 flake8==3.8.3
 jupyterlab==2.2.2
+notebook==6.1.3
 pytest==6.0.1
 selenium==3.141.0

--- a/tests/test_offlinenotebook.py
+++ b/tests/test_offlinenotebook.py
@@ -103,7 +103,7 @@ class TestOfflineNotebook(FirefoxTestBase):
 
     def download_visible(self):
         self.wait.until(EC.element_to_be_clickable(
-            (By.XPATH, "//button[@title='Download']"))).click()
+            (By.XPATH, "//button[@title='Download visible']"))).click()
         size = os.stat(self.expected_download).st_size
         with open(self.expected_download) as f:
             nb = json.load(f)


### PR DESCRIPTION
This ensures notebook releases will be tested.

In the latest `notebook` the title text may be different from the button label