### PR TITLE
JupyterLab 3 pip installable

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,8 +14,55 @@ jobs:
       - uses: actions/setup-python@v2
       - uses: pre-commit/action@v2.0.0
 
+  # Due to complications in the build process when trying to support both JupyterLab
+  # 2 and 3 we build the pypi packages with JupyterLab 3, but test on 2 and 3
+
+  build:
+    name: Build dist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Cache pip
+        uses: actions/cache@v2
+        with:
+          # This path is specific to Ubuntu
+          path: ~/.cache/pip
+          # Look to see if there is a cache hit for the corresponding requirements file
+          key: ${{ runner.os }}-pip-${{ hashFiles('dev-requirements*.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+      - name: Cache yarn
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/yarn
+          key: ${{ runner.os }}-yarn-${{ hashFiles('*.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Install dependencies
+        run: python -mpip install -r dev-requirements-jl3.txt
+      - name: Build dist
+        run: |
+          python setup.py sdist bdist_wheel
+          ls dist/*tar.gz dist/*.whl
+
+      - name: Javascript format
+        run: |
+          jlpm install
+          jlpm run format:check
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: dist
+          path: dist
+          if-no-files-found: error
+
   test:
     name: Pytest
+    needs: build
     strategy:
       # Keep running so we can see if other tests pass
       fail-fast: false
@@ -43,28 +90,22 @@ jobs:
           key: ${{ runner.os }}-pip-${{ hashFiles('dev-requirements*.txt') }}
           restore-keys: |
             ${{ runner.os }}-pip-
-      - name: Cache yarn
-        uses: actions/cache@v2
+      - name: Download artifacts from build
+        uses: actions/download-artifact@v2
         with:
-          path: ~/.cache/yarn
-          key: ${{ runner.os }}-yarn-${{ hashFiles('*.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          name: dist
+          path: dist
 
       - name: Install dependencies
         run: python -mpip install -r dev-requirements-jl${{ matrix.jupyterlab-major }}.txt
       - name: Install plugin
         run: |
-          python setup.py sdist
-          python -mpip install dist/*.tar.gz
-          if [[ {{ matrix.jupyterlab-major }} = 2 ]]; then
-            jlpm
+          python -mpip install dist/*.whl
+          if [[ ${{ matrix.jupyterlab-major }} = 2 ]]; then
             jupyter labextension install --debug --minimize=False
           fi
       - name: Run pytest
         run: pytest -vs tests
-      - name: Javascript Format
-        run: jlpm run format:check
 
   # https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
   publish-pypi:
@@ -77,10 +118,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
-      - name: Build package
-        run: |
-          python -mpip install wheel
-          python setup.py sdist bdist_wheel
+      - name: Download artifacts from build
+        uses: actions/download-artifact@v2
+        with:
+          name: dist
+          path: dist
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@v1.3.0
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,12 +57,14 @@ jobs:
         run: |
           python setup.py sdist
           python -mpip install dist/*.tar.gz
-          jlpm
-          jupyter labextension install --debug
+          if [[ {{ matrix.jupyterlab-major }} = 2 ]]; then
+            jlpm
+            jupyter labextension install --debug --minimize=False
+          fi
       - name: Run pytest
         run: pytest -vs tests
-      - name: Javascript Lint
-        run: jlpm run lint:check
+      - name: Javascript Format
+        run: jlpm run format:check
 
   # https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
   publish-pypi:

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,5 @@
 jupyter_offlinenotebook/static/jslib
+jupyter_offlinenotebook/static/lab/static
 lib
 node_modules
 package.json

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -5,4 +5,4 @@ dependencies:
   - pip
   - python
   - pip:
-      - jupyterlab==3.0.0rc2
+      - jupyterlab==3.0.0rc7

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,19 +1,8 @@
 #!/bin/bash
 set -eux
 
-env | sort
-pwd
-
 # jupyter-offlinenotebook is automatically installed by repo2docker.
-# Uninstall to avoid conflicts
-jupyter labextension uninstall --no-build jupyter-offlinenotebook
+# In JupyterLab 3.0.0rc7 it looks like the older extension is ignored,
+# no need to uninstall it
 
-# repo2docker copies this repo into $HOME which means jupyter labextension
-# picks up hidden dot files and runs into problems so install from a
-# different directory
-SRCDIR=/srv/conda/src/jupyter-offlinenotebook
-mkdir -p "$SRCDIR"
-cp -a * "$SRCDIR"
-cd "$SRCDIR"
 python -m pip install .
-jupyter labextension link --debug

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,4 +4,5 @@ pre-commit==2.8.2
 pytest==6.1.2
 pytest-tornasync==0.6.0
 selenium==3.141.0
+wheel==0.35.1
 # jupyterlab is installed separately so we can test multiple versions

--- a/package.json
+++ b/package.json
@@ -24,20 +24,27 @@
     "type": "git",
     "url": "https://github.com/manics/jupyter-offlinenotebook.git"
   },
+  "//": "We build static extensions for both notebook and lab3 that are installed with pip. To support JupyterLab 2 we must ensure the default build script does not call 'jupyter labextension build' which was added in JupyterLab 3. This means you must run 'jlpm run build:all' or 'jlpm run default' instead of just 'jlpm' for now. When JupyterLab 2 is dropped the 'build' script can be changed to 'jlpm run build:all'",
   "scripts": {
-    "build": "jlpm run build:all",
-    "build:all": "jlpm run build:lib && jlpm run build:webpack",
+    "build": "jlpm run build:lib",
+    "build:all": "jlpm run build:lib && jlpm run build:notebook && jlpm run build:labextension",
+    "build:labextension": "jupyter labextension build .",
+    "build:labextension:dev": "jupyter labextension build --development True .",
     "build:lib": "tsc",
-    "build:webpack": "webpack",
-    "clean": "jlpm run clean:all",
-    "clean:all": "jlpm run clean:lib && jlpm run clean:webpack",
+    "build:notebook": "webpack",
+    "clean": "jlpm run clean:lib && jlpm run clean:notebook && jlpm run clean:labextension",
+    "clean:labextension": "rimraf jupyter_offlinenotebook/static/lab",
     "clean:lib": "rimraf lib tsconfig.tsbuildinfo",
-    "clean:webpack": "rimraf jupyter_offlinenotebook/static/jslib",
-    "install:extension": "pip install -e . && jupyter labextension develop --overwrite .",
-    "link": "jupyter labextension link . --no-build",
-    "lint": "eslint . --ext .ts,.tsx --fix && prettier --write .",
-    "lint:check": "eslint . --ext .ts,.tsx && prettier --list-different .",
+    "clean:notebook": "rimraf jupyter_offlinenotebook/static/jslib",
+    "default": "jlpm run clean && jlpm run build:all",
+    "eslint": "eslint . --ext .ts,.tsx --fix",
+    "eslint:check": "eslint . --ext .ts,.tsx",
+    "format": "jlpm run eslint && jlpm run prettier",
+    "format:check": "jlpm run eslint:check && jlpm run prettier:check",
+    "install:extension": "jupyter labextension develop --overwrite .",
     "prepare": "jlpm run clean && jlpm run build",
+    "prettier": "prettier --write .",
+    "prettier:check": "prettier --list-different .",
     "watch": "run-p watch:src watch:labextension",
     "watch:labextension": "jupyter labextension watch .",
     "watch:src": "tsc -w"
@@ -84,6 +91,6 @@
       }
     },
     "extension": true,
-    "outputDir": "jupyter_offlinenotebook/static"
+    "outputDir": "jupyter_offlinenotebook/static/lab"
   }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
-  "jupyter_packaging~=0.6.0",
-  "jupyterlab>=2",  # jlpm is used to build static js
+  "jupyter_packaging~=0.7.0",
+  "jupyterlab>=3.0.0rc7,==3.*",  # jlpm is used to build static js
   "setuptools>=40.8.0",
   "wheel"
 ]

--- a/setup.py
+++ b/setup.py
@@ -26,8 +26,12 @@ def get_version():
 
 # Representative files that should exist after a successful build
 jstargets = [
+    # tsc
     os.path.join(HERE, "lib", "index.js"),
+    # notebook
     os.path.join(HERE, name, "static", "jslib", "offlinenotebook.js"),
+    # jupyterlab 3 bundled extension
+    os.path.join(HERE, name, "static", "lab", "package.json"),
 ]
 
 # package_data_spec = {
@@ -39,9 +43,6 @@ jstargets = [
 data_files_spec = [
     (f"share/jupyter/nbextensions/{jsname}", f"{name}/static", "*.*"),
     (f"share/jupyter/nbextensions/{jsname}/jslib", f"{name}/static/jslib", "*.*"),
-    # (f'share/jupyter/labextensions/{jsname}',
-    #   f'{name}/static', '*.*'),
-    # ("etc/jupyter/jupyter_server_config.d",
     (
         "etc/jupyter/jupyter_notebook_config.d",
         f"{name}/etc",
@@ -51,6 +52,14 @@ data_files_spec = [
         "etc/jupyter/nbconfig/notebook.d",
         f"{name}/etc",
         "offlinenotebook_nbextension.json",
+    ),
+    # TODO: Why is 'jupyter labextension build' putting the files under
+    # static/lab/static instead of static/lab ?
+    (f"share/jupyter/labextensions/{jsname}", f"{name}/static/lab", "*.*"),
+    (
+        f"share/jupyter/labextensions/{jsname}/static",
+        f"{name}/static/lab/static",
+        "*.*",
     ),
 ]
 


### PR DESCRIPTION
Bundles the JupyterLab 3 extension inside the python package, so there is no longer a need to build the extension.

JupyterLab 2 is unaffected, a build step is still required.