### PR TITLE
Set download type to application/x-ipynb+json

### DIFF
--- a/src/jslib/offlinenotebook.ts
+++ b/src/jslib/offlinenotebook.ts
@@ -100,7 +100,10 @@ export function downloadNotebookFromBrowser(
   name: string,
   nb: PartialJSONValue
 ): void {
-  const blob = new Blob([JSON.stringify(nb)], { type: 'application/json' });
+  const blob = new Blob([JSON.stringify(nb)], {
+    // https://jupyter.readthedocs.io/en/latest/reference/mimetype.html
+    type: 'application/x-ipynb+json',
+  });
   const url = window.URL.createObjectURL(blob);
   const a = document.createElement('a');
   document.body.appendChild(a);

--- a/tests/test_offlinenotebook.py
+++ b/tests/test_offlinenotebook.py
@@ -86,7 +86,7 @@ class FirefoxTestBase:
         profile.set_preference("browser.download.manager.showWhenStarting", "false")
         profile.set_preference("browser.download.dir", downloaddir)
         profile.set_preference(
-            "browser.helperApps.neverAsk.saveToDisk", "application/json"
+            "browser.helperApps.neverAsk.saveToDisk", "application/x-ipynb+json"
         )
 
         options = Options()


### PR DESCRIPTION
This ensures Firefox keeps the ipynb extension instead of overridding it to json

Closes https://github.com/manics/jupyter-offlinenotebook/issues/167