### PR TITLE
Theme toolbar icon color

### DIFF
--- a/style/index.css
+++ b/style/index.css
@@ -3,5 +3,5 @@
  * https://github.com/jupyterlab/jupyterlab/blob/v2.0.1/packages/ui-components/style/base.css#L70-L73
  */
 .jp-OfflineNotebookToolbarIcon {
-  color: var(--md-grey-700);
+  color: var(--jp-inverse-layout-color3);
 }


### PR DESCRIPTION
The current toolbar icon color is not themed. Therefore it does not have high contrast on dark theme:

![image](https://user-images.githubusercontent.com/8435071/150675898-46c6d2d5-b595-4759-a253-7428415dedc6.png)

This update the value to follow the toolbar icon theme of JupyterLab