### PR TITLE
Update/fix CI, stop testing lab 2 / python 3.6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,42 +8,35 @@ jobs:
   # https://github.com/pre-commit/action
   pre-commit:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-      - uses: pre-commit/action@v2.0.0
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+      - uses: pre-commit/action@v3.0.1
 
   # Due to complications in the build process when trying to support both JupyterLab
   # 2 and 3 we build the pypi packages with JupyterLab 3, but test on 2 and 3
 
   build:
     name: Build dist
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
         with:
-          python-version: 3.8
-      - name: Cache pip
-        uses: actions/cache@v2
+          python-version: '3.8'
+          cache: pip
+          cache-dependency-path: 'dev-requirements*'
+
+      - uses: actions/setup-node@v4
         with:
-          # This path is specific to Ubuntu
-          path: ~/.cache/pip
-          # Look to see if there is a cache hit for the corresponding requirements file
-          key: ${{ runner.os }}-pip-${{ hashFiles('dev-requirements*') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-      - name: Cache yarn
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/yarn
-          key: ${{ runner.os }}-yarn-${{ hashFiles('*.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          node-version: '18.x'
+          cache: yarn
 
       - name: Install dependencies
         run: python -mpip install -r dev-requirements-jl3.txt
+
       - name: Build dist
         run: |
           python setup.py sdist bdist_wheel
@@ -59,13 +52,13 @@ jobs:
           mkdir jsdist
           jlpm pack --filename jsdist/jupyter-offlinenotebook-jlpmpack.tgz
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: dist
           path: dist
           if-no-files-found: error
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: jsdist
           path: jsdist
@@ -81,37 +74,43 @@ jobs:
         include:
           - python-version: '3.6'
             jupyterlab-major: '2'
+            ubuntu: '20.04'
+            node: '16.x'
           - python-version: '3.8'
             jupyterlab-major: '3'
-    runs-on: ubuntu-latest
+            ubuntu: '22.04'
+            node: '18.x'
+    runs-on: ubuntu-${{ matrix.ubuntu }}
     # Includes geckdriver and firefox
     # https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu1804-README.md
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Cache pip
-        uses: actions/cache@v2
+          cache: pip
+          cache-dependency-path: 'dev-requirements*'
+
+      - uses: actions/setup-node@v4
         with:
-          # This path is specific to Ubuntu
-          path: ~/.cache/pip
-          # Look to see if there is a cache hit for the corresponding requirements file
-          key: ${{ runner.os }}-pip-${{ hashFiles('dev-requirements*') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
+          node-version: ${{ matrix.node }}
+          cache: yarn
+
       - name: Download artifacts from build
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
 
       - name: Install dependencies
         run: python -mpip install -r dev-requirements-jl${{ matrix.jupyterlab-major }}.*
+
       - name: Install plugin
         run: |
           python -mpip install dist/*.whl
           if [[ ${{ matrix.jupyterlab-major }} = 2 ]]; then
             jupyter labextension install --debug --minimize=False ./jsdist/jupyter-offlinenotebook-jlpmpack.tgz
           fi
+
       - name: Run pytest
         run: pytest -vs tests
 
@@ -122,17 +121,19 @@ jobs:
       # Only publish if other jobs passed
       - pre-commit
       - test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5
+
       - name: Download artifacts from build
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist
+
       - name: Publish to PyPI
         if: startsWith(github.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@v1.3.0
+        uses: pypa/gh-action-pypi-publish@v1.8.11
         with:
           password: ${{ secrets.PYPI_PASSWORD }}
 
@@ -142,15 +143,17 @@ jobs:
       # Only publish if other jobs passed
       - pre-commit
       - test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       # Setup .npmrc file to publish to npm
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v4
         with:
-          node-version: 12.x
+          node-version: '18.x'
+          cache: yarn
           registry-url: https://registry.npmjs.org
+
       - name: Download artifacts from build
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: jsdist
           path: jsdist

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.8'
+          python-version: '3.10'
           cache: pip
           cache-dependency-path: 'dev-requirements*'
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,7 @@ jobs:
         include:
           - python-version: '3.7'
             jupyterlab-major: '3'
-          - python-version: '3.8'
+          - python-version: '3.10'
             jupyterlab-major: '3'
     runs-on: ubuntu-22.04
     # Includes geckdriver and firefox

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,15 +72,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - python-version: '3.6'
-            jupyterlab-major: '2'
-            ubuntu: '20.04'
-            node: '16.x'
+          - python-version: '3.7'
+            jupyterlab-major: '3'
           - python-version: '3.8'
             jupyterlab-major: '3'
-            ubuntu: '22.04'
-            node: '18.x'
-    runs-on: ubuntu-${{ matrix.ubuntu }}
+    runs-on: ubuntu-22.04
     # Includes geckdriver and firefox
     # https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu1804-README.md
     steps:
@@ -95,7 +91,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node }}
+          node-version: '18.x'
           cache: yarn
 
       - name: Download artifacts from build
@@ -107,9 +103,6 @@ jobs:
       - name: Install plugin
         run: |
           python -mpip install dist/*.whl
-          if [[ ${{ matrix.jupyterlab-major }} = 2 ]]; then
-            jupyter labextension install --debug --minimize=False ./jsdist/jupyter-offlinenotebook-jlpmpack.tgz
-          fi
 
       - name: Run pytest
         run: pytest -vs tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,7 +142,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '18.x'
-          cache: yarn
           registry-url: https://registry.npmjs.org
 
       - name: Download artifacts from build

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 24.1.1
     hooks:
       - id: black
         args: [--target-version=py36]
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.9.2
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.0.0
     hooks:
       - id: flake8
         # default black line length is 88

--- a/dev-requirements-jl2.old
+++ b/dev-requirements-jl2.old
@@ -1,2 +1,0 @@
--r dev-requirements.txt
-jupyterlab==2.2.9

--- a/dev-requirements-jl3.txt
+++ b/dev-requirements-jl3.txt
@@ -1,2 +1,2 @@
 -r dev-requirements.txt
-jupyterlab==3.2.8
+jupyterlab==3.6.7

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,9 +1,9 @@
-jupyter_packaging==0.7.12
+jupyter_packaging==0.12.3
 flaky==3.7.0
-notebook==6.4.10
-pre-commit==2.17.0
-pytest==7.0.1
-pytest-tornasync==0.6.0.post2
-selenium==3.141.0
-wheel==0.37.1
+notebook==6.5.4
+pre-commit==2.21.0
+pytest==7.4.4
+selenium==4.11.2
+traitlets==5.9.0
+wheel==0.42.0
 # jupyterlab is installed separately so we can test multiple versions

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 """
 jupyter_offlinenotebook setup
 """
+
 import json
 import os
 

--- a/tests/test_offlinenotebook.py
+++ b/tests/test_offlinenotebook.py
@@ -44,13 +44,13 @@ def assert_empty_size(size):
 
 
 class FirefoxTestBase:
-    def setup(self):
+    def setup_method(self):
         self.jupyter_proc = None
         self.major_version = None
         self.driver = None
         self.wait = None
 
-    def teardown(self):
+    def teardown_method(self):
         try:
             if self.driver:
                 self.driver.quit()

--- a/tests/test_offlinenotebook.py
+++ b/tests/test_offlinenotebook.py
@@ -190,7 +190,7 @@ class TestOfflineNotebook(FirefoxTestBase):
         # https://stackoverflow.com/a/51842120
         self.wait.until(
             EC.invisibility_of_element_located(
-                (By.XPATH, "//div[@class='modal-dialog']")
+                (By.XPATH, "//div[@class='modal-backdrop']")
             )
         )
 

--- a/tests/test_offlinenotebook.py
+++ b/tests/test_offlinenotebook.py
@@ -11,7 +11,6 @@ from selenium.common.exceptions import TimeoutException
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.common.by import By
-from selenium.webdriver.common.keys import Keys
 
 from selenium.webdriver.firefox.firefox_profile import FirefoxProfile
 from selenium.webdriver.firefox.options import Options
@@ -94,6 +93,7 @@ class FirefoxTestBase:
         profile = FirefoxProfile()
         profile.set_preference("browser.download.folderList", 2)
         profile.set_preference("browser.download.manager.showWhenStarting", "false")
+        profile.set_preference("browser.download.alwaysOpenPanel", False)
         profile.set_preference("browser.download.dir", downloaddir)
         profile.set_preference(
             "browser.helperApps.neverAsk.saveToDisk", "application/x-ipynb+json"
@@ -126,9 +126,6 @@ class FirefoxTestBase:
         self.start_jupyter(jupyterdir, app)
         self.initialise_firefox(str(downloaddir), url)
 
-    def escape_key(self):
-        webdriver.ActionChains(self.driver).send_keys(Keys.ESCAPE).perform()
-
 
 class TestOfflineNotebook(FirefoxTestBase):
     def download_visible(self):
@@ -137,8 +134,6 @@ class TestOfflineNotebook(FirefoxTestBase):
                 (By.XPATH, "//button[@title='Download visible']")
             )
         ).click()
-        # Firefox may have left a download panel open which covers other elements
-        self.escape_key()
 
         size = os.stat(self.expected_download).st_size
         with open(self.expected_download) as f:
@@ -246,8 +241,6 @@ class TestOfflineLab(FirefoxTestBase):
 
         # Allow time for the downloaded file to be saved
         sleep(2)
-        # Firefox may have left a download panel open which covers other elements
-        self.escape_key()
 
         size = os.stat(self.expected_download).st_size
         assert size

--- a/tests/test_offlinenotebook.py
+++ b/tests/test_offlinenotebook.py
@@ -102,10 +102,10 @@ class FirefoxTestBase:
         # Comment this out to see the browser window
         options.headless = HEADLESS
 
-        kwargs = {"firefox_profile": profile, "options": options}
+        options.profile = profile
         if FIREFOX_BIN:
-            kwargs["firefox_binary"] = FIREFOX_BIN
-        self.driver = webdriver.Firefox(**kwargs)
+            options.binary_location = FIREFOX_BIN
+        self.driver = webdriver.Firefox(options=options)
         self.wait = WebDriverWait(self.driver, TIMEOUT)
 
         self.driver.get(url)
@@ -141,38 +141,38 @@ class TestOfflineNotebook(FirefoxTestBase):
         return size, ncells
 
     def save_to_browser_storage(self):
-        self.driver.find_element_by_xpath(
-            "//button[@title='Save to browser storage']"
+        self.driver.find_element(
+            By.XPATH, "//button[@title='Save to browser storage']"
         ).click()
         dialog = self.wait.until(
             EC.visibility_of_element_located((By.CSS_SELECTOR, "div.modal-dialog"))
         )
 
-        assert dialog.find_element_by_css_selector("h4.modal-title").text == (
+        assert dialog.find_element(By.CSS_SELECTOR, "h4.modal-title").text == (
             "Notebook saved to browser storage"
         )
-        assert dialog.find_element_by_css_selector("div.modal-body").text == (
+        assert dialog.find_element(By.CSS_SELECTOR, "div.modal-body").text == (
             "repoid: https://github.com/manics/jupyter-offlinenotebook\n"
             "path: example.ipynb"
         )
-        dialog.find_element_by_css_selector("button.btn-default").click()
+        dialog.find_element(By.CSS_SELECTOR, "button.btn-default").click()
 
     def restore_from_browser_storage(self):
-        self.driver.find_element_by_xpath(
-            "//button[@title='Restore from browser storage']"
+        self.driver.find_element(
+            By.XPATH, "//button[@title='Restore from browser storage']"
         ).click()
         dialog = self.wait.until(
             EC.visibility_of_element_located((By.CSS_SELECTOR, "div.modal-dialog"))
         )
 
-        assert dialog.find_element_by_css_selector("h4.modal-title").text == (
+        assert dialog.find_element(By.CSS_SELECTOR, "h4.modal-title").text == (
             "This will replace your current notebook with"
         )
-        assert dialog.find_element_by_css_selector("div.modal-body").text == (
+        assert dialog.find_element(By.CSS_SELECTOR, "div.modal-body").text == (
             "repoid: https://github.com/manics/jupyter-offlinenotebook\n"
             "path: example.ipynb"
         )
-        buttons = dialog.find_elements_by_css_selector("button.btn-default")
+        buttons = dialog.find_elements(By.CSS_SELECTOR, "button.btn-default")
         assert buttons[0].text == "OK"
         assert buttons[1].text == "Cancel"
         buttons[0].click()
@@ -248,8 +248,8 @@ class TestOfflineLab(FirefoxTestBase):
         return size, ncells
 
     def save_to_browser_storage(self):
-        self.driver.find_element_by_xpath(
-            "//button[@title='Save to browser storage']"
+        self.driver.find_element(
+            By.XPATH, "//button[@title='Save to browser storage']"
         ).click()
         dialog = self.wait.until(
             EC.visibility_of_element_located((By.CSS_SELECTOR, "div.jp-Dialog-content"))
@@ -259,18 +259,18 @@ class TestOfflineLab(FirefoxTestBase):
             el = "span"
         else:
             el = "div"
-        assert dialog.find_element_by_css_selector(f"{el}.jp-Dialog-header").text == (
+        assert dialog.find_element(By.CSS_SELECTOR, f"{el}.jp-Dialog-header").text == (
             "Notebook saved to browser storage"
         )
-        assert dialog.find_element_by_css_selector("span.jp-Dialog-body").text == (
+        assert dialog.find_element(By.CSS_SELECTOR, "span.jp-Dialog-body").text == (
             "repoid: https://github.com/manics/jupyter-offlinenotebook "
             "path: example.ipynb"
         )
-        dialog.find_element_by_css_selector("button.jp-Dialog-button").click()
+        dialog.find_element(By.CSS_SELECTOR, "button.jp-Dialog-button").click()
 
     def restore_from_browser_storage(self):
-        self.driver.find_element_by_xpath(
-            "//button[@title='Restore from browser storage']"
+        self.driver.find_element(
+            By.XPATH, "//button[@title='Restore from browser storage']"
         ).click()
         dialog = self.wait.until(
             EC.visibility_of_element_located((By.CSS_SELECTOR, "div.jp-Dialog-content"))
@@ -280,14 +280,14 @@ class TestOfflineLab(FirefoxTestBase):
             el = "span"
         else:
             el = "div"
-        assert dialog.find_element_by_css_selector(f"{el}.jp-Dialog-header").text == (
+        assert dialog.find_element(By.CSS_SELECTOR, f"{el}.jp-Dialog-header").text == (
             "This will replace your current notebook with"
         )
-        assert dialog.find_element_by_css_selector("span.jp-Dialog-body").text == (
+        assert dialog.find_element(By.CSS_SELECTOR, "span.jp-Dialog-body").text == (
             "repoid: https://github.com/manics/jupyter-offlinenotebook "
             "path: example.ipynb"
         )
-        buttons = dialog.find_elements_by_css_selector("button.jp-Dialog-button")
+        buttons = dialog.find_elements(By.CSS_SELECTOR, "button.jp-Dialog-button")
         assert buttons[0].text == "Cancel"
         assert buttons[1].text == "OK"
         buttons[1].click()


### PR DESCRIPTION
It's too difficult to get the Python 3.6/JupyterLab 2 tests working, so test Python 3.7+ and JupyterLab 3 only.