### PR TITLE
 Release candidate 0.3.0-rc.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,15 +111,14 @@ jobs:
 
   # https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
   publish-pypi:
-    if: startsWith(github.ref, 'refs/tags')
     needs:
       # Only publish if other jobs passed
       - pre-commit
       - test
     runs-on: ubuntu-22.04
+    permissions:
+      id-token: write
     steps:
-      - uses: actions/setup-python@v5
-
       - name: Download artifacts from build
         uses: actions/download-artifact@v4
         with:
@@ -129,8 +128,6 @@ jobs:
       - name: Publish to PyPI
         if: startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@v1.8.11
-        with:
-          password: ${{ secrets.PYPI_PASSWORD }}
 
   # https://docs.github.com/en/actions/language-and-framework-guides/publishing-nodejs-packages#publishing-packages-to-the-npm-registry
   publish-npm:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+# 0.3.0-rc.1
+
+JupyterLab 4 support, require Jupyter Server (for Notebook support use NbClassic), drop support for Python 3.6.
+
+([full changelog](https://github.com/manics/jupyter-offlinenotebook/compare/v0.2.2...v0.3.1-rc.1))
+
+### New features
+
+- Drop Python 3.6, test 3.12 [#565](https://github.com/manics/jupyter-offlinenotebook/pull/565) ([@manics](https://github.com/manics))
+- Support JupyterLab 4, Require jupyter-server [#564](https://github.com/manics/jupyter-offlinenotebook/pull/564) ([@manics](https://github.com/manics))
+
+### Other
+
+- Update/fix CI, stop testing lab 2 / python 3.6 [#563](https://github.com/manics/jupyter-offlinenotebook/pull/563) ([@manics](https://github.com/manics))
+- Regenerate yarn.lock [#458](https://github.com/manics/jupyter-offlinenotebook/pull/458) ([@manics](https://github.com/manics))
+- Update .pre-commit-config.yaml versions [#457](https://github.com/manics/jupyter-offlinenotebook/pull/457) ([@manics](https://github.com/manics))
+
+[@dependabot updates](https://github.com/manics/jupyter-offlinenotebook/pulls?q=is%3Apr+author%3Aapp%2Fdependabot+) have been omitted from this Changelog.
+
 # 0.2.2 2022-01-25
 
 ([full changelog](https://github.com/manics/jupyter-offlinenotebook/compare/v0.2.1...v0.2.2))

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -2,6 +2,7 @@ name: offlinenotebook
 channels:
   - defaults
 dependencies:
-  - jupyterlab=4.1.0
+  - jupyterlab>=4,<5
+  - notebook>=7,<8
   - pip
   - python

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyter-offlinenotebook",
-  "version": "0.2.2",
+  "version": "0.3.0rc.1",
   "description": "JupyterLab offline-notebook extension.",
   "keywords": [
     "jupyter",


### PR DESCRIPTION
Switches to PyPI trusted publisher (unfortunately NPM doesn't support that)