### PR TITLE
Use setuptools-scm to include files in sdist, switch to `python -mbuild`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Build dist
         run: |
-          python setup.py sdist bdist_wheel
+          python -mbuild
           ls dist/*tar.gz dist/*.whl
 
       - name: Javascript format

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -4,5 +4,5 @@ image:
 tasks:
   # https://www.gitpod.io/docs/languages/python#start-tasks
   - init: >
-      pip3 install -r dev-requirements-jl3.txt &&
+      pip3 install -r dev-requirements-jl4.txt &&
       pip3 install .

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,24 +1,7 @@
-include LICENSE
-include LICENSE.dexie
-include README.md
-include pyproject.toml
-
-include package.json
-include ts*.json
-include webpack.config.js
-include yarn.lock
+# setuptools-scm includes all source controlled files
 
 graft jupyter_offlinenotebook/static
 
 # Javascript files
-graft src
-graft style
 prune **/node_modules
 prune lib
-
-# Patterns to exclude from any directory
-global-exclude *~
-global-exclude *.pyc
-global-exclude *.pyo
-global-exclude .git
-global-exclude .ipynb_checkpoints

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,6 +6,7 @@ include pyproject.toml
 include package.json
 include ts*.json
 include webpack.config.js
+include yarn.lock
 
 graft jupyter_offlinenotebook/static
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,4 @@
+build==1.0.3
 jupyter_packaging==0.12.3
 flaky==3.7.0
 nbclassic==1.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
-  "jupyter_packaging~=0.7.0",
-  "jupyterlab>=3.0.0,==3.*",  # jlpm is used to build static js
+  "jupyter_packaging~=0.12.3",
+  "jupyterlab~=4.0",  # jlpm is used to build static js
   "setuptools>=40.8.0",
   "wheel"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,12 @@
 requires = [
   "jupyter_packaging~=0.12.3",
   "jupyterlab~=4.0",  # jlpm is used to build static js
-  "setuptools>=40.8.0",
+  "setuptools>=60",
+  "setuptools-scm>=8",
   "wheel"
 ]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+# Used to ensure all files are packaged in the sdist
+# This is not used for versioning

--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,6 @@ def get_version():
 
 # Representative files that should exist after a successful build
 jstargets = [
-    # tsc
-    os.path.join(HERE, "lib", "index.js"),
     # notebook
     os.path.join(HERE, name, "static", "jslib", "offlinenotebook.js"),
     # jupyterlab 3 bundled extension


### PR DESCRIPTION
This should ensure all files are included in the sdist, and that a wheel can be built from the sdist

See https://github.com/conda-forge/jupyter-offlinenotebook-feedstock/pull/6#issuecomment-1937789406