### PR TITLE
Disable NPM in dependabot, add github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
-  - package-ecosystem: npm
+
+  - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly


### PR DESCRIPTION
dependabot should still open NPM security updates